### PR TITLE
id for routing to posts corrected on Home and AllPosts pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom"
 import { firestore } from './firebase'
 import { usePostsUpdate } from "./contexts/PostContext"

--- a/src/components/AllPosts/index.js
+++ b/src/components/AllPosts/index.js
@@ -2,14 +2,12 @@ import React, { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import { usePosts } from "../../contexts/PostContext"
-import { usePostSortToggle } from '../../contexts/PostContext'
 import '../components.css'
 
 function AllPosts() {
   const [state, setState] = useState()
   const [renderArray, setRenderArray] = useState([])
   let postArray = usePosts()
-  const togglePostSort = usePostSortToggle()
 
   useEffect(() => {
     setRenderArray(postArray)
@@ -26,7 +24,6 @@ function AllPosts() {
   const searchHandler = (e) => {
     e.preventDefault()
     searchArray = []
-    togglePostSort()
     console.log('in searchHandler', state)
     let searchString = state.searchbox
     console.log(searchString)

--- a/src/components/Post/index.js
+++ b/src/components/Post/index.js
@@ -3,29 +3,22 @@ import { Redirect } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 
 import { usePosts } from '../../contexts/PostContext'
-import { usePostSortStatus } from '../../contexts/PostContext'
-import { usePostSortToggle } from '../../contexts/PostContext'
 
 import HomeNav from '../HomeNav'
 import '../postContent.css'
 
 function Post(props) {
   const postArray = usePosts()
-  const postSort = usePostSortStatus()
-  const togglePostSort = usePostSortToggle()
   console.log('Post: postArray', postArray)
   // const postIndex = postArray.length
   let id = parseInt(props.match.params.id)
 
-  if (postSort) {
-    function findPostId(element) {
-      return element.postId === id
-    }
-    id = postArray.findIndex(findPostId)
-    togglePostSort()
+  function findPostId(element) {
+    return element.postId === id
   }
+  id = postArray.findIndex(findPostId)
 
-  console.log('id: ', id)
+  console.log('POST id after sort: ', id)
   const maxValidId = postArray[0].postId
   console.log('maxValidId', maxValidId)
 

--- a/src/components/PostList/index.js
+++ b/src/components/PostList/index.js
@@ -24,7 +24,7 @@ function PostList() {
         array.map((post, i) => {
           return (
             <div className="post-card" key={post.postId}>
-              <Link className='post-link' to={`/post/${i}`}>
+              <Link className='post-link' to={`/post/${post.postId}`}>
                 <h2 className='post-title'>{post.title}</h2>
                 <small>Published on {post.date}</small>
                 <hr></hr>

--- a/src/contexts/PostContext.js
+++ b/src/contexts/PostContext.js
@@ -34,7 +34,6 @@ export function PostProvider({ children }) {
     setPostSort(prevPostSort => !prevPostSort)
   }
 
-  console.log('PostContext: postArray', postArray)
 
   return (
     <PostContext.Provider value={postArray}>


### PR DESCRIPTION
Corrected issue where the post id from the Home page was incorrect interpreted.  Now, clicking on any post on either the Home or AllPosts pages routes to the correct post.